### PR TITLE
Fix permissions on license files

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -18,6 +18,10 @@ for file in ./crosstool_ng/packages/binutils/${PKG_VERSION}/*.patch; do
   patch -p1 < $file;
 done
 
+# Fix permissions on license files--not sure why these are world-writable, but that's how
+# they come from the upstream tarball
+chmod og-w COPYING*
+
 mkdir build
 cd build
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "binutils" %}
 {% set version = "2.35.1" %}
 {% set chost = ctng_cpu_arch ~ "-" ~ ctng_vendor ~ "-linux-gnu-" %}
-{% set build_num = 0 %}
+{% set build_num = 1 %}
 
 package:
   name: binutils_split


### PR DESCRIPTION
They come from upstream world-writable for some reason and end up directly copied into the end package--which then installs them as world-writable. This flags on some security checks.

Fixes #45 .
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
