### PR TITLE
Disable -u mode in bash in case it is set

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
       - patches/0001-fallback-sysroot.diff
 
 build:
-  number: 2
+  number: 3
   skip: true  # [win64 and cross_target_platform != "win-64"]
   detect_binary_files_with_prefix: false
 

--- a/recipe/scripts/activate-binutils.sh
+++ b/recipe/scripts/activate-binutils.sh
@@ -1,5 +1,8 @@
 # shellcheck shell=sh
 
+# This script expands variables that potentially do not exist. In case -u is enabled, this will fail.
+set +u
+
 # This function takes no arguments
 # It tries to determine the name of this file in a programatic way.
 _get_sourced_filename() {


### PR DESCRIPTION
When -u is activated, the activation script fails when expanding variables such as ADDR2LINE in case they are not set (which they are usually not). To make -u workable which is generally a usable debugging tool, this change disables it just for this script

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
